### PR TITLE
fix: unit tests are only running on windows

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,8 +102,9 @@ macro_rules! __trail {
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
+
     #[test]
-    #[cfg(windows)]
     fn trail() {
         if cfg!(windows) {
             assert_eq!(trail!(), Path::new(""));


### PR DESCRIPTION
No wonder they passed without `use std::path::Path;`!